### PR TITLE
Card Pool Adjustments

### DIFF
--- a/SweetkinBackOnTrack.Plugin/json/cards/Sw_Hospitality.json
+++ b/SweetkinBackOnTrack.Plugin/json/cards/Sw_Hospitality.json
@@ -22,6 +22,7 @@
       "targets_room": true,
       "targetless": false,
       "cost": 1,
+      "pools": [ "StarterCardsOnly" ],
       "effects": [
         "@RaiseHp_hospy"
       ]

--- a/SweetkinBackOnTrack.Plugin/json/cards/Sw_WinterSnowstorms.json
+++ b/SweetkinBackOnTrack.Plugin/json/cards/Sw_WinterSnowstorms.json
@@ -19,6 +19,7 @@
       "targetless": true,
       "card_type": "blight",
       "cost": 1,
+      "pools": ["StarterCardsOnly"],
       "triggers": [
         "@WinterReserve"
       ]

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_BookCook.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_BookCook.json
@@ -20,7 +20,10 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentMerchant_RoomAndEquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 2,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_BookMint.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_BookMint.json
@@ -20,7 +20,10 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentMerchant_RoomAndEquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 2,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_ButlerSuit.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_ButlerSuit.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 1,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_CombatKnife.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_CombatKnife.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 1,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_CrabBib.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_CrabBib.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 2,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_Dovelivery.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_Dovelivery.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 1,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_LilSpoon.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_LilSpoon.json
@@ -24,7 +24,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 2,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_LimeBook.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_LimeBook.json
@@ -20,7 +20,10 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentMerchant_RoomAndEquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 0,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_MaidSuit.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_MaidSuit.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 1,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_Sparelimb.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_Sparelimb.json
@@ -20,7 +20,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 1,
       "traits": [

--- a/SweetkinBackOnTrack.Plugin/json/equipments/Sw_TuningFork.json
+++ b/SweetkinBackOnTrack.Plugin/json/equipments/Sw_TuningFork.json
@@ -15,7 +15,9 @@
       "targetless": false,
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_EquipmentPool"
+        "RoomAndEquipmentMerchant_EquipmentPool",
+        "RoomAndEquipmentDraftPool",
+        "EquipmentPoolNonEnemy"
       ],
       "cost": 2,
       "effects": [

--- a/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomGrav.json
+++ b/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomGrav.json
@@ -27,7 +27,8 @@
       ],
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_RoomPool"
+        "RoomAndEquipmentMerchant_RoomPool",
+        "RoomAndEquipmentDraftPool"
       ]
     }
   ],

--- a/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomKitchen.json
+++ b/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomKitchen.json
@@ -27,7 +27,8 @@
       ],
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_RoomPool"
+        "RoomAndEquipmentMerchant_RoomPool",
+        "RoomAndEquipmentDraftPool"
       ]
     }
   ],

--- a/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomLobby.json
+++ b/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomLobby.json
@@ -28,7 +28,9 @@
       ],
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_RoomPool"
+        "RoomAndEquipmentMerchant_RoomPool",
+        "RoomAndEquipmentMerchant_RoomAndEquipmentPool",
+        "RoomAndEquipmentDraftPool"
       ]
     }
   ],

--- a/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomRestaurant.json
+++ b/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomRestaurant.json
@@ -28,7 +28,8 @@
       ],
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_RoomPool"
+        "RoomAndEquipmentMerchant_RoomPool",
+        "RoomAndEquipmentDraftPool"
       ]
     }
   ],

--- a/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomSpa.json
+++ b/SweetkinBackOnTrack.Plugin/json/rooms/Sw_RoomSpa.json
@@ -27,7 +27,8 @@
       ],
       "pools": [
         "MegaPool",
-        "RoomAndEquipmentMerchant_RoomPool"
+        "RoomAndEquipmentMerchant_RoomPool",
+        "RoomAndEquipmentDraftPool"
       ]
     }
   ],

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -11,7 +11,7 @@ containsNsfwContent = false
 
 [package.dependencies]
 BepInEx-BepInExPack = "5.4.2100"
-MT2-Trainworks_Reloaded = "0.5.2"
+MT2-Trainworks_Reloaded = "0.5.4"
 
 [build]
 icon = "./icon.png"


### PR DESCRIPTION
Partial Card Pool Adjustments.  Please review if all of these make sense if it doesn't let me know and I can append a change.

1. Moves both starter cards to the `StarterCardsOnly` pool. This allows the starter cards to be cost reduced by Vola's Tuning Fork.
2. All Equipment and Rooms is added to `RoomAndEquipmentDraftPool` so they can be found as a draft pick for Armory when playing as Sweetkin (primary or allied)
3. Rare Equipment and Rooms are added to `RoomAndEquipmentMerchant_RoomAndEquipmentPool` as the third slot in the Equipment shop sells rare equipment/rooms
4. All Equipment is added to `EquipmentPoolNonEnemy` so Swordmaiden can draw Sweetkin equipment with her summon trigger.

**ACTION REQUIRED**
Things that I did not do and you should consider doing on your own time.

For each equipment card you have. If it makes sense to have the card when not playing Sweetkin as primary or allied clan:

1. Does it make sense for Truffles to be able to draw it? add it to "FreeEquipmentMutatorPool"
2. Does it make sense to have it randomly equipped with the Red Crown effect? add it to "RedCrownEquipmentPool"
3. Does it make sense to have the equipment randomly grafted onto a unit in the Lazarus League event? add it to "RandomGraftedEquipmentForEvent_NoVoidArms_EquipmentPool"

For each room card you have. If it makes sense to get the room card when not playing Sweetkin as primary or allied clan:

1. The It's free real estate mutator gives 2 room cards for free. If you would like a Sweetkin room to be part of the pool in the room card add it to the "TrainRoomPool" pool
